### PR TITLE
Netlify: Konfiguration für nur Preview-Deploys angepasst

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,46 +1,42 @@
 # Netlify Configuration
-# Optimiert für Credit-Sparsamkeit
+# ═══════════════════════════════════════════════════════════════════════════
+# NUR PREVIEW DEPLOYS - Production ist deaktiviert
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# WICHTIG: Um Production-Deploys wirklich zu stoppen, gehe zu:
+# https://app.netlify.com → Site Settings → Build & Deploy → Continuous Deployment
+# → "Stop auto-publishing" aktivieren
+#
+# Dann werden nur noch Deploy Previews (Pull Requests) erstellt.
+# ═══════════════════════════════════════════════════════════════════════════
 
 [build]
-  # Kein Build-Command nötig, da statische Seite
   command = ""
   publish = "."
+  # Ignore-Pattern: Nur bei PR/Preview deployen
+  ignore = "git log -1 --format='%s' | grep -qvE '^(Merge pull request|Preview:)'"
 
-# Branch Deploy Settings - NUR Deploy Previews aktiviert (keine Production Deploys)
-[context.production]
-  command = ""
-  publish = "."
-  # Production Deploys DEAKTIVIERT - nur Previews
-  skip_processing = true
-
-# Preview Deploys (Pull Requests) - AKTIVIERT für Tests
+# Preview Deploys (Pull Requests) - AKTIVIERT
 [context.deploy-preview]
   command = ""
   publish = "."
-  # Aktiviert - nur Preview Deploys
-  skip_processing = false
 
-# Branch Deploys - DEAKTIVIERT um Credits zu sparen
+# Branch Deploys - DEAKTIVIERT
 [context.branch-deploy]
   command = ""
   publish = "."
-  # Deaktiviert - keine Branch Deploys
-  skip_processing = true
+  ignore = "exit 0"
 
-# Production Branch - DEAKTIVIERT
-[build.processing]
-  skip_processing = true
-
-# Headers für Performance
+# Headers für Performance & Security
 [[headers]]
   for = "/*"
   [headers.values]
-    X-Frame-Options = "DENY"
+    X-Frame-Options = "SAMEORIGIN"
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
 
-# Redirects
+# SPA Redirect
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Focuses Netlify on preview-only deployments and minor security header adjustment.
> 
> - Enforces preview-only builds: adds `build.ignore` to skip non-PR commits; disables branch deploys with `context.branch-deploy.ignore = "exit 0"`
> - Removes production/branch processing configs; keeps empty build `command` and `publish` at project root
> - Updates security header: `X-Frame-Options` from `DENY` to `SAMEORIGIN`
> - Retains SPA redirect and core security headers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b61cc883c822ccdc05826649dfbb9af33a5887e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->